### PR TITLE
DEV-60 공통 스타일 지정 및 reset css 적용

### DIFF
--- a/src/commons/styles/styles.ts
+++ b/src/commons/styles/styles.ts
@@ -22,12 +22,160 @@ export const color = {
   $defaultGray: '#dee2e6',
   $lightGray: '#F1F3F5',
   $lightestGray: '#F8F9FA',
+
+  /* color token */
+  primary: '#4263EB',
+  secondary: '#F5F7FE',
+
+  // gray -> Figma - color token 에 있는 gray 임을 주의
+  gray: {
+    gray10: '#212529',
+    gray20: '#868E96',
+    gray30: '#ADB5BD',
+    gray40: '#DEE2E6',
+    gray50: '#F1F3F5',
+    gray60: '#F8F9FA',
+  },
+
+  text: {
+    black: '#212529',
+    gray: '#868E96',
+    white: '#FFFFFF',
+    placeholder: '#868E96',
+    disabled: '#ADB5BD',
+    main: '#4263eb',
+  },
+
+  bg: {
+    base: '#FFFFFF',
+    transaprent: '#ADB5BD1A',
+  },
+
+  border: {
+    default: '#DEE2E6',
+  },
+
+  /* color palette */
+  blue: {
+    blue20: '#B3C1F7',
+    blue30: '#8EA1F3',
+  },
+
+  red: {
+    red5: '#FEF2F2',
+    red60: '#DC2626',
+  },
+
+  teal: {
+    teal10: '#E0F5F6',
+    teal60: '#45B9C4',
+  },
+}
+
+export const typography = {
+  heading1: css`
+    font-size: 50px;
+    font-weight: 700;
+    line-height: 1.3;
+
+    @media (max-width: 360px) {
+      font-size: 36px;
+    }
+  `,
+  heading2: css`
+    font-size: 38px;
+    font-weight: 700;
+    line-height: 1.3;
+
+    @media (max-width: 360px) {
+      font-size: 32px;
+      line-height: 1.2;
+    }
+  `,
+  heading3: css`
+    font-size: 28px;
+    font-weight: 700;
+    line-height: 1.3;
+
+    @media (max-width: 360px) {
+      font-size: 24px;
+      line-height: 1.4;
+    }
+  `,
+  heading4: css`
+    font-size: 22px;
+    font-weight: 700;
+    line-height: 1.5;
+
+    @media (max-width: 360px) {
+      font-size: 20px;
+    }
+  `,
+  subheading: css`
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.5;
+  `,
+  body1: {
+    bold: css`
+      font-size: 16px;
+      line-height: 1.5;
+      font-weight: 700;
+    `,
+    medium: css`
+      font-size: 16px;
+      line-height: 1.5;
+      font-weight: 500;
+    `,
+    light: css`
+      font-size: 16px;
+      line-height: 1.5;
+      font-weight: 300;
+    `,
+  },
+  body2: {
+    bold: css`
+      font-size: 14px;
+      line-height: 1.5;
+      font-weight: 700;
+    `,
+    medium: css`
+      font-size: 14px;
+      line-height: 1.5;
+      font-weight: 500;
+    `,
+    light: css`
+      font-size: 14px;
+      line-height: 1.5;
+      font-weight: 300;
+    `,
+  },
+  caption: {
+    bold: css`
+      font-size: 12px;
+      line-height: 1.5;
+      font-weight: 700;
+    `,
+    medium: css`
+      font-size: 12px;
+      line-height: 1.5;
+      font-weight: 500;
+    `,
+    light: css`
+      font-size: 12px;
+      line-height: 1.5;
+      font-weight: 300;
+    `,
+  },
 }
 
 export const globalStyles = css`
+  @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css');
+
   * {
     margin: 0px;
     box-sizing: border-box;
     color: #212529;
+    font-family: 'Pretendard', sans-serif;
   }
 `

--- a/src/commons/styles/styles.ts
+++ b/src/commons/styles/styles.ts
@@ -173,9 +173,53 @@ export const globalStyles = css`
   @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css');
 
   * {
-    margin: 0px;
-    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    font: inherit;
     color: #212529;
-    font-family: 'Pretendard', sans-serif;
+    box-sizing: border-box;
+  }
+  *,
+  :after,
+  :before {
+    box-sizing: border-box;
+    flex-shrink: 0;
+  }
+  :root {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    cursor: default;
+    line-height: 1.5;
+    overflow-wrap: break-word;
+    -moz-tab-size: 4;
+    tab-size: 4;
+  }
+  html {
+    font-family: 'Pretendard', 'Noto Sans', sans-serif;
+  }
+  html,
+  body {
+    height: 100%;
+  }
+  img,
+  picture,
+  video,
+  canvas,
+  svg {
+    display: block;
+    max-width: 100%;
+  }
+  button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+  }
+  a {
+    text-decoration: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
   }
 `

--- a/src/components/units/home/Home.tsx
+++ b/src/components/units/home/Home.tsx
@@ -12,9 +12,9 @@ const Home = () => {
   return (
     <Styled.Container>
       <div style={{ width: '80%' }}>
-        <Tag text={'default'} />
+        {/* <Tag text={'default'} />
         <Tag text={'hi'} color={color.$warning} />
-        <Tag text={'bye'} color={color.$main} />
+        <Tag text={'bye'} color={color.$main} /> */}
         <div>
           <Styled.GuideBox>
             <div>펀딩 목록</div>


### PR DESCRIPTION
### Rest css
블로그 글을 참고하여 reset css 적용해봤습니다.

- 참고: https://velog.io/@teo/2022-CSS-Reset-%EB%8B%A4%EC%8B%9C-%EC%8D%A8%EB%B3%B4%EA%B8%B0

<br />

### Font
폰트 Pretendard 지정

<br />

### Color
Figma 에 있는 color token 변수로 생성

(💡 기존에 추가했었던 color 변수는 충돌날까봐 일단 지우지 않았습니다.)

<br />

- gray (기존 Hierarchy에서 gray로 이름 변경)
- text
- bg(background)
- border
- primary, secondary (main)
- 위의 color token 으로 지정한 색상 외 color palette 에 있는 색상 사용하고 싶으면 아래와 같이 지정해서 사용하는 것은 어떨까요? 모두 다른 이름을 지정해서 하기에는 애매할 것 같다는 생각에 의견 제시해봅니다.

  ```css
  red: {
    red5: '#FEF2F2',
    red60: '#DC2626',
  }
  ```

<br />

### Typography
heading1 ~ heading4 는 데스크탑과 모바일에 따라 폰트 사이즈가 달라집니다. (반응형?적용)

글꼴의 font-weight 는  700, 500, 300 을 사용합니다.

제목(heading1 ~ subheading)의 font-weight 는 700 입니다.

그 외(body1 ~ caption)의 font-weight 는 700(bold), 500(medium), 300(light) 입니다.

- heading1
- heading2
- heading3
- heading4
- subheading
- body1
    - bold
    - medium
    - light
- body2
    - bold
    - medium
    - light
- caption
    - bold
    - medium
    - light